### PR TITLE
Add Turkish language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The versioning scheme is compliant with the [PEP 440](https://peps.python.org/pep-0440/#public-version-identifiers) specification.
 
+## Unreleased – 2025‑07‑23
+
+### Added
+- Turkish language support for internationalization
+  - Added `TurkishLocale` class with Turkish month names, day names, and notations
+  - Updated `Language` type to include `"tr"` for Turkish language support
+
 ## 2.5.0 - 2024-05-25
 
 - Added a new function called `year_length()`, which calculates the total number of days in a Hijri year.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,7 +113,7 @@ TypeError: '>' not supported between instances of 'Hijri' and 'str'
 
 ## Internationalization
 
-Representation of weekday names, month names, and calendar notations is supported. English `en` is the default language. Additionally, Arabic `ar` and Bangla `bn` translations are available, but it can be easily extended for other natural languages.
+Representation of weekday names, month names, and calendar notations is supported. English `en` is the default language. Additionally, Arabic `ar`, Bangla `bn`, and Turkish `tr` translations are available, but it can be easily extended for other natural languages.
 
 The following is an example showing how to use the Arabic language:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,3 +212,6 @@ isort = { combine-as-imports = true, lines-between-types = 1 }
     "D10", # Missing docstrings
     "PLR2004", # Magic value used in comparison
 ]
+"src/hijridate/locales.py" = [
+    "RUF001", # Allow Turkish characters like ı, ş, ç, etc.
+]

--- a/src/hijridate/locales.py
+++ b/src/hijridate/locales.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar, Dict, Literal, Tuple, Type
 
-Language = Literal["en", "ar", "bn"]
+Language = Literal["en", "ar", "bn", "tr"]
 
 _locale_map: Dict[str, Type["Locale"]] = {}
 
@@ -197,3 +197,48 @@ class BengaliLocale(Locale):
     )
     notation = "হিজরি"
     gregorian_notation = "খ্রিস্টাব্দ"
+
+
+class TurkishLocale(Locale):
+    """A Turkish Locale object represents Turkish locale-specific data."""
+
+    language_tag = "tr"
+    month_names = (
+        "Muharrem",
+        "Safer",
+        "Rebiülevvel",
+        "Rebiülahir",
+        "Cemaziyelevvel",
+        "Cemaziyelahir",
+        "Recep",
+        "Şaban",
+        "Ramazan",
+        "Şevval",
+        "Zilkade",
+        "Zilhicce",
+    )
+    gregorian_month_names = (
+        "Ocak",
+        "Şubat",
+        "Mart",
+        "Nisan",
+        "Mayıs",
+        "Haziran",
+        "Temmuz",
+        "Ağustos",
+        "Eylül",
+        "Ekim",
+        "Kasım",
+        "Aralık",
+    )
+    day_names = (
+        "Pazartesi",
+        "Salı",
+        "Çarşamba",
+        "Perşembe",
+        "Cuma",
+        "Cumartesi",
+        "Pazar",
+    )
+    notation = "Hicri"
+    gregorian_notation = "Miladi"

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -12,7 +12,7 @@ g_max_iso = "-".join([f"{i:02}" for i in g_max])
 
 
 def test_importing_at_init_module():
-    from hijridate import Gregorian, Hijri
+    from hijridate import Gregorian, Hijri  # noqa: PLC0415
 
     assert Hijri(1410, 8, 13)
     assert Gregorian(1990, 3, 10)
@@ -87,6 +87,7 @@ class TestHijri:
         assert self.hijri_date.month_name() == "Sha'ban"
         assert self.hijri_date.month_name("en") == "Sha'ban"
         assert self.hijri_date.month_name("en-US") == "Sha'ban"
+        assert self.hijri_date.month_name("tr") == "Şaban"
 
     def test_weekday(self):
         assert self.hijri_date.weekday() == 5
@@ -98,11 +99,13 @@ class TestHijri:
         assert self.hijri_date.day_name() == "Saturday"
         assert self.hijri_date.day_name("en") == "Saturday"
         assert self.hijri_date.day_name("en-US") == "Saturday"
+        assert self.hijri_date.day_name("tr") == "Cumartesi"
 
     def test_notation(self):
         assert self.hijri_date.notation() == "AH"
         assert self.hijri_date.notation("en") == "AH"
         assert self.hijri_date.notation("en-US") == "AH"
+        assert self.hijri_date.notation("tr") == "Hicri"
 
     def test_to_julian(self):
         assert self.hijri_date.to_julian() == 2447961
@@ -180,16 +183,19 @@ class TestGregorian:
         assert self.gregorian_date.month_name() == "March"
         assert self.gregorian_date.month_name("en") == "March"
         assert self.gregorian_date.month_name("en-US") == "March"
+        assert self.gregorian_date.month_name("tr") == "Mart"
 
     def test_day_name(self):
         assert self.gregorian_date.day_name() == "Saturday"
         assert self.gregorian_date.day_name("en") == "Saturday"
         assert self.gregorian_date.day_name("en-US") == "Saturday"
+        assert self.gregorian_date.day_name("tr") == "Cumartesi"
 
     def test_notation(self):
         assert self.gregorian_date.notation() == "CE"
         assert self.gregorian_date.notation("en") == "CE"
         assert self.gregorian_date.notation("en-US") == "CE"
+        assert self.gregorian_date.notation("tr") == "Miladi"
 
     def test_to_julian(self):
         assert self.gregorian_date.to_julian() == 2447961


### PR DESCRIPTION
# Add Turkish language support

This PR adds full Turkish (`tr`) localization to hijridate: month names, day names, and notations.

## Changes

- **New locale class**  
  - `src/hijridate/locales.py`: added `class TurkishLocale(Locale)` with Turkish month & day names and notations.

- **Typing**  
  - Extended `Language = Literal[...]` to include `"tr"`.

- **Documentation**  
  - Updated `docs/usage.md` to list `tr` under “Internationalization.”

- **Changelog**  
  - Added an **Unreleased – 2025‑07‑23** entry in `CHANGELOG.md` under **Added**.

- **Linter/config**  
  - In `pyproject.toml`, added a `per-file-ignores` entry so Ruff skips the `RUF001` rule in `locales.py` (to allow Turkish characters like ı, ş, ç, etc.).

- **Tests**  
  - In `tests/unit/test_convert.py`:
    - Marked the in‑test import with `# noqa: PLC0415`.
    - Added assertions for Turkish:
      - `.month_name("tr")`
      - `.day_name("tr")`
      - `.notation("tr")`
    - Covered both Hijri and Gregorian classes.
